### PR TITLE
Allow n1ql queries

### DIFF
--- a/couchbase-lite/src/fl_slice.rs
+++ b/couchbase-lite/src/fl_slice.rs
@@ -82,6 +82,15 @@ impl AsFlSlice for FlSliceOwner {
     }
 }
 
+impl AsFlSlice for FLSliceResult {
+    fn as_flslice(&self) -> FLSlice {
+        FLSlice {
+            buf: self.buf,
+            size: self.size,
+        }
+    }
+}
+
 #[inline]
 pub(crate) unsafe fn fl_slice_to_str_unchecked<'a>(s: FLSlice) -> &'a str {
     let bytes: &[u8] = slice::from_raw_parts(s.buf as *const u8, s.size);

--- a/couchbase-lite/src/lib.rs
+++ b/couchbase-lite/src/lib.rs
@@ -204,6 +204,10 @@ impl Database {
     pub fn query(&self, query_json: &str) -> Result<Query> {
         Query::new(self, query_json)
     }
+    /// Compiles a query from an expression given as N1QL.
+    pub fn n1ql_query(&self, query: &str) -> Result<Query> {
+        Query::new_n1ql(self, query)
+    }
 
     /// Creates an enumerator ordered by docID.
     pub fn enumerate_all_docs(&self, flags: DocEnumeratorFlags) -> Result<DocEnumerator> {

--- a/couchbase-lite/src/query.rs
+++ b/couchbase-lite/src/query.rs
@@ -39,6 +39,24 @@ impl Query<'_> {
             .ok_or_else(|| c4err.into())
     }
 
+    pub(crate) fn new_n1ql<'a, 'b>(db: &'a Database, query_n1ql: &'b str) -> Result<Query<'a>> {
+        let mut c4err = c4error_init();
+        let mut out_error_pos: std::os::raw::c_int = -1;
+        let query = unsafe {
+            c4query_new2(
+                db.inner.0.as_ptr(),
+                kC4N1QLQuery,
+                query_n1ql.as_bytes().as_flslice(),
+                &mut out_error_pos,
+                &mut c4err,
+            )
+        };
+
+        NonNull::new(query)
+            .map(|inner| Query { _db: db, inner })
+            .ok_or_else(|| c4err.into())
+    }
+
     pub fn run(&self) -> Result<Enumerator> {
         let mut c4err = c4error_init();
         let it = unsafe {

--- a/couchbase-lite/src/query.rs
+++ b/couchbase-lite/src/query.rs
@@ -5,7 +5,7 @@ use crate::{
         c4queryenum_free, c4queryenum_next, kC4DefaultQueryOptions, kC4N1QLQuery, C4Query,
         C4QueryEnumerator, FLArrayIterator_GetCount, FLArrayIterator_GetValueAt, FLSlice_Copy,
     },
-    fl_slice::{fl_slice_empty, AsFlSlice, FlSliceOwner},
+    fl_slice::{fl_slice_empty, AsFlSlice},
     value::{FromValueRef, ValueRef},
     Database, Result,
 };
@@ -65,7 +65,6 @@ impl Query<'_> {
         let param_string = serde_json::to_string(parameters)?;
         let param_slice = param_string.as_bytes().as_flslice();
         let param_copy = unsafe { FLSlice_Copy(param_slice) };
-        let param_copy: FlSliceOwner = param_copy.into();
 
         unsafe {
             c4query_setParameters(self.inner.as_ptr(), param_copy.as_flslice());

--- a/couchbase-lite/src/query.rs
+++ b/couchbase-lite/src/query.rs
@@ -3,7 +3,7 @@ use crate::{
     ffi::{
         c4query_free, c4query_new, c4query_new2, c4query_run, c4query_setParameters,
         c4queryenum_free, c4queryenum_next, kC4DefaultQueryOptions, kC4N1QLQuery, C4Query,
-        C4QueryEnumerator, FLArrayIterator_GetCount, FLArrayIterator_GetValueAt, FLSlice_Copy,
+        C4QueryEnumerator, FLArrayIterator_GetCount, FLArrayIterator_GetValueAt,
     },
     fl_slice::{fl_slice_empty, AsFlSlice},
     value::{FromValueRef, ValueRef},
@@ -64,10 +64,8 @@ impl Query<'_> {
     {
         let param_string = serde_json::to_string(parameters)?;
         let param_slice = param_string.as_bytes().as_flslice();
-        let param_copy = unsafe { FLSlice_Copy(param_slice) };
-
         unsafe {
-            c4query_setParameters(self.inner.as_ptr(), param_copy.as_flslice());
+            c4query_setParameters(self.inner.as_ptr(), param_slice);
         }
         Ok(())
     }

--- a/couchbase-lite/src/query.rs
+++ b/couchbase-lite/src/query.rs
@@ -58,7 +58,7 @@ impl Query<'_> {
             .ok_or_else(|| c4err.into())
     }
 
-    pub fn set_json_parameters<T>(&self, parameters: &T) -> Result<()>
+    pub fn set_parameters<T>(&self, parameters: &T) -> Result<()>
     where
         T: Serialize,
     {

--- a/couchbase-lite/tests/smoke_tests.rs
+++ b/couchbase-lite/tests/smoke_tests.rs
@@ -499,3 +499,50 @@ fn test_like_performance() {
     }
     tmp_dir.close().expect("Can not close tmp_dir");
 }
+
+#[test]
+fn test_n1ql_query() {
+    let _ = env_logger::try_init();
+    let tmp_dir = tempdir().expect("Can not create tmp directory");
+    println!("we create tempdir at {}", tmp_dir.path().display());
+    let db_path = tmp_dir.path().join("a.cblite2");
+    {
+        let mut db = Database::open(&db_path, DatabaseConfig::default()).unwrap();
+        let mut trans = db.transaction().unwrap();
+        for i in 0..10_000 {
+            let foo = Foo {
+                i,
+                s: format!("Hello {}", i),
+            };
+            let mut doc = Document::new(&foo).unwrap();
+            trans.save(&mut doc).unwrap();
+        }
+        trans.commit().unwrap();
+
+        let query = db.n1ql_query("SELECT s WHERE s LIKE '%555'").unwrap();
+        let expected = vec![
+            "Hello 1555",
+            "Hello 2555",
+            "Hello 3555",
+            "Hello 4555",
+            "Hello 555",
+            "Hello 5555",
+            "Hello 6555",
+            "Hello 7555",
+            "Hello 8555",
+            "Hello 9555",
+        ];
+
+        let mut iter = query.run().unwrap();
+        let mut query_ret = Vec::with_capacity(10);
+        while let Some(item) = iter.next().unwrap() {
+            let val = item.get_raw_checked(0).unwrap();
+            let val = val.as_str().unwrap();
+            query_ret.push(val.to_string());
+        }
+        query_ret.sort();
+
+        assert_eq!(expected, query_ret);
+    }
+    tmp_dir.close().expect("Can not close tmp_dir");
+}

--- a/couchbase-lite/tests/smoke_tests.rs
+++ b/couchbase-lite/tests/smoke_tests.rs
@@ -570,7 +570,7 @@ fn test_n1ql_query_with_parameter() {
             .n1ql_query("SELECT s WHERE s LIKE $pattern ORDER BY s LIMIT 2 OFFSET 1")
             .unwrap();
         query
-            .set_json_parameters(&serde_json::json!({
+            .set_parameters(&serde_json::json!({
                 "pattern": "%555",
             }))
             .unwrap();


### PR DESCRIPTION
Adds a way to execute n1ql queries on a database.
Depends on a pull request on duchitov/couchbase-lite-core : https://github.com/Dushistov/couchbase-lite-core/pull/1

I tested it with the couchbase-lite-core submodule updated with  the additional change (exposes c4query_setParameters) but have not done the submodule update in this pull request.

Any comments on naming, code style etc. welcome.