### PR TITLE
handle typo get_existsing/get_existing

### DIFF
--- a/chat-demo/src/main.rs
+++ b/chat-demo/src/main.rs
@@ -192,7 +192,7 @@ fn print_all_messages(db: &Database) -> Result<(), Box<dyn std::error::Error>> {
         let id = item.get_raw_checked(0)?;
         let id = id.as_str()?;
         println!("iteration id {}", id);
-        let doc = db.get_existsing(id)?;
+        let doc = db.get_existing(id)?;
         println!("doc id {}", doc.id());
 
         let db_msg: Message = doc.decode_data()?;
@@ -217,7 +217,7 @@ fn print_external_changes(db: &mut Option<Database>) -> Result<(), Box<dyn std::
         }
     }
     for doc_id in &doc_ids {
-        let doc = match db.get_existsing(doc_id.as_str()) {
+        let doc = match db.get_existing(doc_id.as_str()) {
             Ok(x) => x,
             Err(err) => {
                 eprintln!("Can not get {}: {}", doc_id, err);

--- a/couchbase-lite/Cargo.toml
+++ b/couchbase-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "couchbase-lite"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Evgeniy A. Dushistov <dushistov@mail.ru>"]
 edition = "2018"
 

--- a/couchbase-lite/src/lib.rs
+++ b/couchbase-lite/src/lib.rs
@@ -30,7 +30,7 @@
 //!     while let Some(item) = iter.next()? {
 //!         let id = item.get_raw_checked(0)?;
 //!         let id = id.as_str()?;
-//!         let doc = db.get_existsing(id)?;
+//!         let doc = db.get_existing(id)?;
 //!         println!("doc id {}", doc.id());
 //!         let db_msg: Message = doc.decode_data()?;
 //!         println!("db_msg: {:?}", db_msg);
@@ -193,11 +193,19 @@ impl Database {
         unsafe { c4db_getDocumentCount(self.inner.0.as_ptr()) }
     }
     /// Return existing document from database
+    #[deprecated(
+        since = "0.1.0",
+        note = "Please use get_existing (note the removed 's' after the 't')."
+    )]
     pub fn get_existsing(&self, doc_id: &str) -> Result<Document> {
         self.internal_get(doc_id, true)
             .map(|x| Document::new_internal(x, doc_id))
     }
-
+    /// Return existing document from database
+    pub fn get_existing(&self, doc_id: &str) -> Result<Document> {
+        self.internal_get(doc_id, true)
+            .map(|x| Document::new_internal(x, doc_id))
+    }
     /// Compiles a query from an expression given as JSON.
     /// The expression is a predicate that describes which documents should be returned.
     /// A separate, optional sort expression describes the ordering of the results.

--- a/couchbase-lite/src/lib.rs
+++ b/couchbase-lite/src/lib.rs
@@ -192,15 +192,7 @@ impl Database {
     pub fn document_count(&self) -> u64 {
         unsafe { c4db_getDocumentCount(self.inner.0.as_ptr()) }
     }
-    /// Return existing document from database
-    #[deprecated(
-        since = "0.1.0",
-        note = "Please use get_existing (note the removed 's' after the 't')."
-    )]
-    pub fn get_existsing(&self, doc_id: &str) -> Result<Document> {
-        self.internal_get(doc_id, true)
-            .map(|x| Document::new_internal(x, doc_id))
-    }
+
     /// Return existing document from database
     pub fn get_existing(&self, doc_id: &str) -> Result<Document> {
         self.internal_get(doc_id, true)

--- a/couchbase-lite/tests/smoke_tests.rs
+++ b/couchbase-lite/tests/smoke_tests.rs
@@ -53,7 +53,7 @@ fn test_write_read() {
         }
         assert_eq!(ids_and_data.len() as u64, db.document_count());
         for (doc_id, foo) in &ids_and_data {
-            let doc = db.get_existsing(doc_id).unwrap();
+            let doc = db.get_existing(doc_id).unwrap();
             let loaded_foo: Foo = doc.decode_data().unwrap();
             assert_eq!(*foo, loaded_foo);
         }
@@ -63,7 +63,7 @@ fn test_write_read() {
         let mut db = Database::open(&db_path, DatabaseConfig::default()).unwrap();
         assert_eq!(ids_and_data.len() as u64, db.document_count());
         for (doc_id, foo) in &ids_and_data {
-            let doc = db.get_existsing(doc_id).unwrap();
+            let doc = db.get_existing(doc_id).unwrap();
             let loaded_foo: Foo = doc.decode_data().unwrap();
             assert_eq!(*foo, loaded_foo);
         }
@@ -71,7 +71,7 @@ fn test_write_read() {
         {
             let mut trans = db.transaction().unwrap();
             for (doc_id, foo) in &ids_and_data {
-                let mut doc = trans.get_existsing(doc_id).unwrap();
+                let mut doc = trans.get_existing(doc_id).unwrap();
                 let mut foo_updated = foo.clone();
                 foo_updated.i += 1;
                 doc.update_data(&foo_updated).unwrap();
@@ -81,7 +81,7 @@ fn test_write_read() {
         }
         assert_eq!(ids_and_data.len() as u64, db.document_count());
         for (doc_id, foo) in &ids_and_data {
-            let doc = db.get_existsing(doc_id).unwrap();
+            let doc = db.get_existing(doc_id).unwrap();
             let loaded_foo: Foo = doc.decode_data().unwrap();
             assert_eq!(
                 Foo {
@@ -123,7 +123,7 @@ fn test_write_read() {
         {
             let mut trans = db.transaction().unwrap();
             for doc_id in ids_and_data.iter().take(n).map(|x| x.0.as_str()) {
-                let mut doc = trans.get_existsing(doc_id).unwrap();
+                let mut doc = trans.get_existing(doc_id).unwrap();
                 trans.delete(&mut doc).unwrap();
             }
             trans.commit().unwrap();
@@ -170,7 +170,7 @@ fn test_observed_changes() {
 
         {
             let mut trans = db.transaction().unwrap();
-            let mut doc = trans.get_existsing(&doc_id).unwrap();
+            let mut doc = trans.get_existing(&doc_id).unwrap();
             trans.delete(&mut doc).unwrap();
             trans.commit().unwrap();
         }
@@ -182,7 +182,7 @@ fn test_observed_changes() {
         assert!(!changes[0].external());
         assert_eq!(2, changes[0].body_size());
 
-        let doc = db.get_existsing(&doc_id).unwrap();
+        let doc = db.get_existing(&doc_id).unwrap();
         println!("doc {:?}", doc);
         doc.decode_data::<Empty>().unwrap();
     }
@@ -208,7 +208,7 @@ fn test_save_float() {
         let doc_id: String = doc.id().into();
         drop(doc);
 
-        let doc = db.get_existsing(&doc_id).unwrap();
+        let doc = db.get_existing(&doc_id).unwrap();
         let loaded_s: S = doc.decode_data().unwrap();
         assert_eq!(s, loaded_s);
     }
@@ -238,7 +238,7 @@ fn test_save_several_times() {
         drop(doc);
         assert_eq!(1, db.document_count());
 
-        let doc = db.get_existsing(&doc_id).unwrap();
+        let doc = db.get_existing(&doc_id).unwrap();
         assert_eq!(s, doc.decode_data::<S>().unwrap());
 
         let s = create_s(501);
@@ -249,7 +249,7 @@ fn test_save_several_times() {
         drop(doc);
         assert_eq!(1, db.document_count());
 
-        let doc = db.get_existsing(&doc_id).unwrap();
+        let doc = db.get_existing(&doc_id).unwrap();
         assert_eq!(s, doc.decode_data::<S>().unwrap());
 
         let s = create_s(400);
@@ -261,7 +261,7 @@ fn test_save_several_times() {
         drop(doc);
         assert_eq!(1, db.document_count());
 
-        let doc = db.get_existsing(&doc_id).unwrap();
+        let doc = db.get_existing(&doc_id).unwrap();
         assert_eq!(s, doc.decode_data::<S>().unwrap());
     }
     tmp_dir.close().expect("Can not close tmp_dir");
@@ -324,7 +324,7 @@ fn test_indices() {
             let id = item.get_raw_checked(0).unwrap();
             let id = id.as_str().unwrap();
             println!("iteration id {}", id);
-            let doc = db.get_existsing(id).unwrap();
+            let doc = db.get_existing(id).unwrap();
             println!("doc id {}", doc.id());
 
             let foo: Foo = doc.decode_data().unwrap();


### PR DESCRIPTION
At this stage, mostly a request for comment.
Would you agree with the intent (fixing this typo)?
Would you agree with the way it's done? (deprecating v.s. just changing the spelling and changing version to 0.2.0)