### PR TITLE
remove tokio-tungstenite from patch sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 members = ["couchbase-lite-core-sys", "couchbase-lite", "chat-demo"]
 
 [patch.'crates-io']
+# waiting https://github.com/hyperium/http/pull/422
 http = { git = "https://github.com/Dushistov/http", rev = "3ad3b825edc3a0d9048a6af5ab524f2fc51bde30" }
-tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite", rev = "dff4d7209b5f8c4299a2e2be9f46bd79217fda48" }
 couchbase-lite = { path = "couchbase-lite" }
 couchbase-lite-core-sys = { path = "couchbase-lite-core-sys" }
+# waiting https://github.com/alexcrichton/cmake-rs/issues/96
+# and https://github.com/alexcrichton/cmake-rs/pull/101
 cmake = { git = "https://github.com/Dushistov/cmake-rs", rev = "125fe65e123f9bd4ceaf91924b0a381d473f2d97" }

--- a/couchbase-lite/Cargo.toml
+++ b/couchbase-lite/Cargo.toml
@@ -19,7 +19,7 @@ fallible-streaming-iterator = "0.1.9"
 bitflags = "1.2.1"
 once_cell = "1.2.0"
 log = "0.4.8"
-tokio-tungstenite = { version = "0.10.1", optional = true }
+tokio-tungstenite = { version = "0.11.0", optional = true }
 http = { version = "0.2.1", optional = true }
 tokio = { version = "0.2", default-features = false, features = ["sync", "macros"], optional = true }
 futures-util = { version = "0.3.5", optional = true }


### PR DESCRIPTION
the current release of tokio-tungstenite contains all suitable fixes
add notes about

https://github.com/hyperium/http/pull/422
https://github.com/alexcrichton/cmake-rs/issues/96
https://github.com/alexcrichton/cmake-rs/pull/101