### PR TITLE
can test if a document exists with the get_existing_or_empty

### DIFF
--- a/couchbase-lite/src/lib.rs
+++ b/couchbase-lite/src/lib.rs
@@ -202,6 +202,13 @@ impl Database {
         self.internal_get(doc_id, true)
             .map(|x| Document::new_internal(x, doc_id))
     }
+
+    /// Return existing document from database or create new empty one
+    pub fn get_or_empty(&self, doc_id: &str) -> Result<Document> {
+        self.internal_get(doc_id, false)
+            .map(|x| Document::new_internal(x, doc_id))
+    }
+
     /// Compiles a query from an expression given as JSON.
     /// The expression is a predicate that describes which documents should be returned.
     /// A separate, optional sort expression describes the ordering of the results.


### PR DESCRIPTION
My need is to can call a function to test the document existence from it's id.
I can use the get existing and analyse the C4Error (not found) but it's not beautiful for me
I can add a get_existing_or_empty (my PR) and call the exists function (https://github.com/Dushistov/couchbase-lite-rust/pull/45) on the Document to test it's existence. More sexy but not the best
Or I can add a get_document with a Result<Option<Document>> as result. It's seem to be the best

What do you think ?
