### PR TITLE
Support for Replicator basic auth for Tokio sockets

### DIFF
--- a/couchbase-lite/Cargo.toml
+++ b/couchbase-lite/Cargo.toml
@@ -9,7 +9,7 @@ default = ["bundled", "use-couchbase-lite-sqlite", "use-tokio-websocket", "nativ
 bundled = ["couchbase-lite-core-sys/bundled", "serde-fleece/bundled"]
 use-couchbase-lite-sqlite = ["couchbase-lite-core-sys/use-couchbase-lite-sqlite", "serde-fleece/use-couchbase-lite-sqlite"]
 with-asan = ["couchbase-lite-core-sys/with-asan", "serde-fleece/with-asan"]
-use-tokio-websocket = ["tokio-tungstenite", "tokio", "futures-util"]
+use-tokio-websocket = ["tokio-tungstenite", "tokio", "futures-util", "http-auth-basic"]
 native-tls = ["tokio-tungstenite/native-tls"]
 use-couchbase-lite-websocket = ["couchbase-lite-core-sys/use-couchbase-lite-websocket"]
 
@@ -20,6 +20,7 @@ log = "0.4"
 tokio = { version = "1.16.1", optional = true, default-features = false, features = ["rt", "sync", "macros", "time"] }
 tokio-tungstenite = { version = "0.17.1", optional = true, default-features = false, features = ["connect"] }
 futures-util = { version = "0.3", optional = true, default-features = false }
+http-auth-basic = { version = "0.3", optional = true }
 # TODO: remove deps when https://github.com/rust-lang/rust/issues/44930
 # was merged
 va_list = "0.1"

--- a/couchbase-lite/src/lib.rs
+++ b/couchbase-lite/src/lib.rs
@@ -63,8 +63,9 @@ pub use crate::{
     doc_enumerator::DocEnumeratorFlags,
     document::{Document, DocumentFlags},
     error::Error,
+    fallible_streaming_iterator::FallibleStreamingIterator,
     index::IndexType,
-    replicator::ReplicatorState,
+    replicator::{ReplicatorAuthentication, ReplicatorState},
 };
 pub use couchbase_lite_core_sys as ffi;
 pub use fallible_streaming_iterator;

--- a/couchbase-lite/src/value.rs
+++ b/couchbase-lite/src/value.rs
@@ -1,10 +1,10 @@
 use crate::{
     error::{Error, Result},
     ffi::{
-        FLArray, FLArray_Count, FLArray_Get, FLArray_IsEmpty, FLDict, FLDict_Count, FLDict_IsEmpty,
-        FLValue, FLValueType, FLValue_AsArray, FLValue_AsBool, FLValue_AsDict, FLValue_AsDouble,
-        FLValue_AsInt, FLValue_AsString, FLValue_AsUnsigned, FLValue_GetType, FLValue_IsDouble,
-        FLValue_IsInteger, FLValue_IsUnsigned,
+        FLArray, FLArray_Count, FLArray_Get, FLArray_IsEmpty, FLDict, FLDict_Count, FLDict_Get,
+        FLDict_IsEmpty, FLSlice, FLValue, FLValueType, FLValue_AsArray, FLValue_AsBool,
+        FLValue_AsDict, FLValue_AsDouble, FLValue_AsInt, FLValue_AsString, FLValue_AsUnsigned,
+        FLValue_GetType, FLValue_IsDouble, FLValue_IsInteger, FLValue_IsUnsigned,
     },
 };
 use std::convert::TryFrom;
@@ -91,6 +91,12 @@ impl ValueRefDict {
     }
     pub fn is_empty(&self) -> bool {
         unsafe { FLDict_IsEmpty(self.0) }
+    }
+    pub(crate) unsafe fn get_raw(&self, key: FLSlice) -> FLValue {
+        FLDict_Get(self.0, key)
+    }
+    pub fn get(&self, key: FLSlice) -> ValueRef {
+        unsafe { self.get_raw(key) }.into()
     }
 }
 

--- a/couchbase-lite/tests/functional_tests.rs
+++ b/couchbase-lite/tests/functional_tests.rs
@@ -651,7 +651,7 @@ fn test_double_replicator_restart() {
         let handle = runtime.handle().clone();
         db.start_replicator(
             "ws://127.0.0.1:4984/demo/",
-            None,
+            ReplicatorAuthentication::None,
             move |repl_state| {
                 println!("repl_state changed: {:?}", repl_state);
                 if let ReplicatorState::Idle = repl_state {


### PR DESCRIPTION
Aligns Tokio socket auth support with the corresponding LiteCore options