### PR TITLE
remove couchbase-lite-core submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,17 @@ jobs:
       RUSTUP_MAX_RETRIES: 10
       CARGO_NET_RETRY: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Checkout couchbase-lite-core
+        uses: actions/checkout@v3
         with:
+          repository: 'couchbase/couchbase-lite-core'
+          ref: 'bdb7abe064a3366281b2399bf823cfe6a255f7d2'
           submodules: 'recursive'
-
+          path: 'couchbase-lite-core'
+      - name: Export path to c++ library
+        run: |
+          echo "CORE_SRC=$GITHUB_WORKSPACE/couchbase-lite-core" >> $GITHUB_ENV
       # We need to disable the existing toolchain to avoid updating rust-docs
       # which takes a long time. The fastest way to do this is to rename the
       # existing folder, as deleting it takes about as much time as not doing
@@ -97,9 +104,17 @@ jobs:
       RUSTUP_MAX_RETRIES: 10
       CARGO_NET_RETRY: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Checkout couchbase-lite-core
+        uses: actions/checkout@v3
         with:
+          repository: 'couchbase/couchbase-lite-core'
+          ref: 'bdb7abe064a3366281b2399bf823cfe6a255f7d2'
           submodules: 'recursive'
+          path: 'couchbase-lite-core'
+      - name: Export path to c++ library
+        run: |
+          echo "CORE_SRC=$GITHUB_WORKSPACE/couchbase-lite-core" >> $GITHUB_ENV
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -138,9 +153,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Checkout couchbase-lite-core
+        uses: actions/checkout@v3
         with:
+          repository: 'couchbase/couchbase-lite-core'
+          ref: 'bdb7abe064a3366281b2399bf823cfe6a255f7d2'
           submodules: 'recursive'
+          path: 'couchbase-lite-core'
+      - name: Export path to c++ library
+        run: |
+          echo "CORE_SRC=$GITHUB_WORKSPACE/couchbase-lite-core" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8.2'
@@ -166,9 +189,17 @@ jobs:
     name: Checks with rustc/nightly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Checkout couchbase-lite-core
+        uses: actions/checkout@v3
         with:
+          repository: 'couchbase/couchbase-lite-core'
+          ref: 'bdb7abe064a3366281b2399bf823cfe6a255f7d2'
           submodules: 'recursive'
+          path: 'couchbase-lite-core'
+      - name: Export path to c++ library
+        run: |
+          echo "COUCHBASE_LITE_CORE_SRC_DIR=$GITHUB_WORKSPACE/couchbase-lite-core" >> $GITHUB_ENV
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -176,16 +207,10 @@ jobs:
           toolchain: nightly
           override: true
           components: rust-src,rustfmt,clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          # Need to use `cargo rustdoc` to actually get it to respect -D
-          # warnings... Note: this also requires nightly.
-          command: rustdoc
-          args: -p couchbase-lite -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: -p couchbase-lite-core-sys -- -D warnings
+      - name: rustdoc for couchbase-lite
+        run: cargo rustdoc -p couchbase-lite --no-default-features --features="build-cpp,use-couchbase-lite-sqlite,use-tokio-websocket,use-native-tls" -- -D warnings
+      - name: rustdoc for couchbase-lite-core-sys
+        run: cargo rustdoc -p couchbase-lite-core-sys --no-default-features --features="build,use-couchbase-lite-sqlite" -- -D warnings
       - name: Tests with asan
         env:
           RUSTFLAGS: -Zsanitizer=address -Cdebuginfo=0
@@ -196,4 +221,4 @@ jobs:
           # leak sanitization, but we don't care about backtraces here, so long
           # as the other tests have them.
           RUST_BACKTRACE: "0"
-        run: cargo -Z build-std test --features="bundled,use-couchbase-lite-sqlite,with-asan" --target x86_64-unknown-linux-gnu
+        run: cargo -Z build-std test --no-default-features --features="build-cpp,use-couchbase-lite-sqlite,use-tokio-websocket,use-native-tls,with-asan" --target x86_64-unknown-linux-gnu

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "couchbase-lite-core-sys/couchbase-lite-core"]
-	path = couchbase-lite-core-sys/couchbase-lite-core
-	url = https://github.com/couchbase/couchbase-lite-core

--- a/chat-demo/Cargo.toml
+++ b/chat-demo/Cargo.toml
@@ -5,15 +5,16 @@ authors = ["Evgeniy A. Dushistov <dushistov@mail.ru>"]
 edition = "2021"
 
 [features]
-default = ["bundled", "use-couchbase-lite-sqlite", "use-tokio-websocket"]
-bundled = ["couchbase-lite/bundled", "serde-fleece/bundled"]
+default = ["build-cpp", "git-download-cpp", "use-couchbase-lite-sqlite", "use-tokio-websocket"]
+build-cpp = ["couchbase-lite/build-cpp", "serde-fleece/build-cpp"]
+git-download-cpp = ["couchbase-lite/git-download-cpp", "serde-fleece/git-download-cpp"]
 use-couchbase-lite-sqlite = ["couchbase-lite/use-couchbase-lite-sqlite"]
 use-couchbase-lite-websocket = ["couchbase-lite/use-couchbase-lite-websocket"]
 use-tokio-websocket = ["couchbase-lite/use-tokio-websocket", "couchbase-lite/use-native-tls"]
 
 [dependencies]
-couchbase-lite = { version = "0.6.0", default-features = false }
-serde-fleece = { version = "0.1.0", default-features = false }
+couchbase-lite = { version = "0.7.0", default-features = false }
+serde-fleece = { version = "0.2.0", default-features = false }
 env_logger = "0.9"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/ci/build_and_run_tests.py
+++ b/ci/build_and_run_tests.py
@@ -26,8 +26,7 @@ def get_src_root_path(my_path: str) -> str:
 @show_timing
 def build_and_test_cpp_part(src_root: str) -> None:
     cmake_build_dir = os.path.join(src_root, "build-cmake")
-    cmake_src_dir = os.path.join(src_root, "couchbase-lite-core-sys",
-                                 "couchbase-lite-core")
+    cmake_src_dir = os.environ["CORE_SRC"]
     mkdir_if_not_exists(cmake_build_dir)
     print("Current path: %s" % os.environ["PATH"])
     check_call(["cmake", "-DCMAKE_BUILD_TYPE=RelWithDebInfo", cmake_src_dir],
@@ -58,7 +57,7 @@ def build_and_test_rust_part_for_ios(src_root: str) -> None:
     print("build for iOS")
     # Because of https://github.com/alexcrichton/cmake-rs/issues/96 , cmake-rs can not
     # handle build for iOS, so time for manual build
-    cpp_src = os.path.join(src_root, "couchbase-lite-core-sys", "couchbase-lite-core")
+    cpp_src = os.environ["CORE_SRC"]
     cpp_build_dir = os.path.join(cpp_src, "build-ios")
     mkdir_if_not_exists(cpp_build_dir)
     check_call(["cmake", cpp_src, "-DCMAKE_OSX_ARCHITECTURES=arm64", "-DCMAKE_OSX_SYSROOT=iphoneos", "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.0", "-DCMAKE_SYSTEM_NAME=iOS", "-DDISABLE_LTO_BUILD=True", "-DMAINTAINER_MODE=False", "-DENABLE_TESTING=False", "-DLITECORE_BUILD_TESTS=False", "-DSQLITE_ENABLE_RTREE=True", "-DCMAKE_C_FLAGS=-fPIC --target=aarch64-apple-ios -fembed-bitcode", "-DCMAKE_C_COMPILER=/usr/bin/clang", "-DCMAKE_CXX_FLAGS=-fPIC --target=aarch64-apple-ios -fembed-bitcode", "-DCMAKE_CXX_COMPILER=/usr/bin/clang++", "-DCMAKE_ASM_FLAGS=-fPIC --target=aarch64-apple-ios -fembed-bitcode", "-DCMAKE_ASM_COMPILER=/usr/bin/clang", "-DCMAKE_BUILD_TYPE=Debug"], cwd = cpp_build_dir)

--- a/couchbase-lite-core-sys/Cargo.toml
+++ b/couchbase-lite-core-sys/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "couchbase-lite-core-sys"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Evgeniy A. Dushistov <dushistov@mail.ru>"]
 edition = "2021"
 
 [features]
-default = ["bundled", "use-couchbase-lite-sqlite"]
-# use bundled couchbase-lite-core
-bundled = ["cmake"]
+default = ["build", "git-download", "use-couchbase-lite-sqlite"]
+# build couchbase-lite-core from source code
+build = ["cmake"]
+git-download = ["which"]
 # use bundled sqlite in bundled couchbase-lite-core
 use-couchbase-lite-sqlite = []
 with-asan = []
@@ -18,4 +19,5 @@ cmake = { version = "0.1.45", optional = true }
 cc = { version = "1.0.53", default-features = false }
 # we don't need clap, because of don't use bindgen as executable
 bindgen = { version = "0.59.2", default-features = false, features = ["runtime", "which-rustfmt"] }
+which = { version = "4.2.1", optional = true, default-features = false }
 env_logger = "0.9"

--- a/couchbase-lite/Cargo.toml
+++ b/couchbase-lite/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "couchbase-lite"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Evgeniy A. Dushistov <dushistov@mail.ru>"]
 edition = "2021"
 
 [features]
-default = ["bundled", "use-couchbase-lite-sqlite", "use-tokio-websocket", "use-native-tls"]
-bundled = ["couchbase-lite-core-sys/bundled", "serde-fleece/bundled"]
+default = ["build-cpp", "git-download-cpp", "use-couchbase-lite-sqlite", "use-tokio-websocket", "use-native-tls"]
+build-cpp = ["couchbase-lite-core-sys/build", "serde-fleece/build-cpp"]
+git-download-cpp = ["couchbase-lite-core-sys/git-download", "serde-fleece/git-download-cpp"]
 use-couchbase-lite-sqlite = ["couchbase-lite-core-sys/use-couchbase-lite-sqlite", "serde-fleece/use-couchbase-lite-sqlite"]
 with-asan = ["couchbase-lite-core-sys/with-asan", "serde-fleece/with-asan"]
 use-tokio-websocket = ["tokio-tungstenite", "tokio", "futures-util"]
@@ -14,8 +15,8 @@ use-native-tls = ["tokio-tungstenite/native-tls"]
 use-couchbase-lite-websocket = ["couchbase-lite-core-sys/use-couchbase-lite-websocket"]
 
 [dependencies]
-couchbase-lite-core-sys = { version = "0.5.1", default-features = false }
-serde-fleece = { version = "0.1.0", default-features = false }
+couchbase-lite-core-sys = { version = "0.6.0", default-features = false }
+serde-fleece = { version = "0.2.0", default-features = false }
 log = "0.4"
 tokio = { version = "1.16.1", optional = true, default-features = false, features = ["rt", "sync", "macros", "time"] }
 tokio-tungstenite = { version = "0.17.1", optional = true, default-features = false, features = ["connect"] }

--- a/serde-fleece/Cargo.toml
+++ b/serde-fleece/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "serde-fleece"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [features]
-default = ["bundled", "use-couchbase-lite-sqlite"]
-bundled = ["couchbase-lite-core-sys/bundled"]
+default = ["build-cpp", "git-download-cpp", "use-couchbase-lite-sqlite"]
+build-cpp = ["couchbase-lite-core-sys/build"]
+git-download-cpp = ["couchbase-lite-core-sys/git-download"]
 use-couchbase-lite-sqlite = ["couchbase-lite-core-sys/use-couchbase-lite-sqlite"]
 with-asan = ["couchbase-lite-core-sys/with-asan"]
 
 [dependencies]
-couchbase-lite-core-sys = { version = "0.5", default-features = false }
+couchbase-lite-core-sys = { version = "0.6.0", default-features = false }
 serde = { version = "1.0", default-features = false }
 itoa = "1.0"
 ryu = "1.0"


### PR DESCRIPTION
couchbase-lite-core too big to use as submodule,
so just possible to set source code via environment or automatically
download via git